### PR TITLE
Hh ember tutorial bug fixes

### DIFF
--- a/source/posts/2014-05-07-building-an-ember-app-with-rails-part-1.md
+++ b/source/posts/2014-05-07-building-an-ember-app-with-rails-part-1.md
@@ -82,7 +82,7 @@ on your machine omit `-d postgresql`
 Now the ember project:
 
 ```bash
-ember new bostonember
+ember new bostonember --skip-git
 mv bostonember ember
 ```
 
@@ -105,16 +105,9 @@ ember server
 In your browser visit `http://localhost:4200` and you should see "Welcome to Ember.js"
 
 At this point you can put everything in your top level directory under
-version control.  First, remove the git repo that ember-cli generates for you in the `ember/` directory:
+version control:
 
 ```bash
-rm -rf .git
-```
-
-Then initialize a git repo in your top level directory:
-
-```bash
-cd ..
 git init
 git add -A
 gc -m "Initial commit"

--- a/source/posts/2014-05-07-building-an-ember-app-with-rails-part-1.md
+++ b/source/posts/2014-05-07-building-an-ember-app-with-rails-part-1.md
@@ -109,7 +109,7 @@ version control:
 
 ```bash
 git init
-git add -A
+git add .
 gc -m "Initial commit"
 ```
 

--- a/source/posts/2014-05-07-building-an-ember-app-with-rails-part-1.md
+++ b/source/posts/2014-05-07-building-an-ember-app-with-rails-part-1.md
@@ -138,8 +138,10 @@ Now everything related to the Asset Pipeline is completely removed.
 Add the following to the `Gemfile`:
 
 ```ruby
-gem 'active_model_serializers'
+gem 'active_model_serializers', '0.8.3'
 ```
+
+**Note:** If you're using Rails 4.2, you'll need to specify version 0.8.3 for the active\_model\_serializers gem.
 
 If you don't have Postgres on your machine you can set this for
 Production only:

--- a/source/posts/2014-05-07-building-an-ember-app-with-rails-part-1.md
+++ b/source/posts/2014-05-07-building-an-ember-app-with-rails-part-1.md
@@ -59,7 +59,7 @@ Or a greater version.
 
 For this project we will keep our Rails and our Ember apps in separate
 directories with a top-level directory containing the two. We'll have to
-do some project generating and renaming. 
+do some project generating and renaming.
 
 I first create a new top-level directory:
 
@@ -105,11 +105,18 @@ ember server
 In your browser visit `http://localhost:4200` and you should see "Welcome to Ember.js"
 
 At this point you can put everything in your top level directory under
-version control:
+version control.  First, remove the git repo that ember-cli generates for you in the `ember/` directory:
 
 ```bash
+rm -rf .git
+```
+
+Then initialize a git repo in your top level directory:
+
+```bash
+cd ..
 git init
-git add .
+git add -A
 gc -m "Initial commit"
 ```
 
@@ -151,7 +158,7 @@ Run `bundle install` in your `rails` directory. Let's commit our
 changes:
 
 ```bash
-git add .
+git add -A
 gc -m "Removed asset pipeline and added active_model_serializers in Rails"
 ```
 

--- a/source/posts/2014-05-08-building-an-ember-app-with-rails-part-2.md
+++ b/source/posts/2014-05-08-building-an-ember-app-with-rails-part-2.md
@@ -11,7 +11,7 @@ published: true
 tags: ember, ruby, ruby on rails
 ---
 
-We need to start this part with a bug fix. There is a bug for the live reload. In `ember/tests/helpers/start-app.js` 
+If you are using an older version of ember-cli, you'll need to start this part with a bug fix. There is a bug for the live reload. In `ember/tests/helpers/start-app.js`
 insert the 2nd line:
 
 ```js
@@ -26,9 +26,7 @@ Router.reopen({
 });
 ```
 
-This bug exists in `0.0.27` of ember-cli and will hopefully be fixed in a future verision.
-
-([there is a pending PR to fix this](https://github.com/stefanpenner/ember-cli/issues/667))
+(This bug exists in `0.0.27` of ember-cli and [has been fixed](https://github.com/stefanpenner/ember-cli/issues/667) in a subsequent version.)
 
 Now start your server:
 
@@ -61,7 +59,6 @@ up.
 ```js
 import Ember from 'ember';
 import startApp from 'bostonember/tests/helpers/start-app';
-import Ember from 'ember';
 
 var App;
 

--- a/source/posts/2014-05-08-building-an-ember-app-with-rails-part-2.md
+++ b/source/posts/2014-05-08-building-an-ember-app-with-rails-part-2.md
@@ -11,24 +11,7 @@ published: true
 tags: ember, ruby, ruby on rails
 ---
 
-If you are using an older version of ember-cli, you'll need to start this part with a bug fix. There is a bug for the live reload. In `ember/tests/helpers/start-app.js`
-insert the 2nd line:
-
-```js
-var Router = require('bostonember/router')['default'];
-```
-
-Now on line 16 add:
-
-```js
-Router.reopen({
-  location: 'none'
-});
-```
-
-(This bug exists in `0.0.27` of ember-cli and [has been fixed](https://github.com/stefanpenner/ember-cli/issues/667) in a subsequent version.)
-
-Now start your server:
+Start your server:
 
 ```bash
 cd ember

--- a/source/posts/2014-05-09-building-an-ember-app-with-rails-part-3.md
+++ b/source/posts/2014-05-09-building-an-ember-app-with-rails-part-3.md
@@ -113,6 +113,7 @@ Ember CLI Addon to quickly set up Pretender:
 
 ```js
 npm install --save-dev ember-cli-pretender
+ember install:addon ember-cli-pretender
 ```
 
 Tell `JSHint` to ignore the `Pretender` constant.  Open up
@@ -137,6 +138,7 @@ We should be in a good place to write our tests.
 // ember/tests/integration/speakers-page-test.js
 import Ember from 'ember';
 import startApp from 'bostonember/tests/helpers/start-app';
+import Pretender from 'pretender';
 
 var App, server;
 

--- a/source/posts/2014-05-09-building-an-ember-app-with-rails-part-3.md
+++ b/source/posts/2014-05-09-building-an-ember-app-with-rails-part-3.md
@@ -24,6 +24,7 @@ Our first navigation test will be an easy one, create
 `ember/tests/integration/about-page-test.js`
 
 ```js
+import Ember from 'ember';
 import startApp from 'bostonember/tests/helpers/start-app';
 
 var App;
@@ -134,6 +135,7 @@ We should be in a good place to write our tests.
 
 ```js
 // ember/tests/integration/speakers-page-test.js
+import Ember from 'ember';
 import startApp from 'bostonember/tests/helpers/start-app';
 
 var App, server;

--- a/source/posts/2014-05-09-building-an-ember-app-with-rails-part-3.md
+++ b/source/posts/2014-05-09-building-an-ember-app-with-rails-part-3.md
@@ -301,7 +301,7 @@ in the game.
 
 Let's generate a model from our Rails app `rails g model speaker name:string`
 
-Add some seed data
+Add some seed data:
 
 ```ruby
 # rails/db/seeds.rb
@@ -310,9 +310,9 @@ Speaker.create(name: 'Wile E. Coyote')
 Speaker.create(name: 'Yosemite Sam')
 ```
 
-Create, migrate and seed `rake db:create db:migrate db:seed`
+Create, migrate and seed `rake db:create db:migrate db:seed`.
 
-Add a `speakers` resource under an `api` namespace`
+Add a `speakers` resource under an `api` namespace:
 
 ```ruby
 # rails/config/routes.rb
@@ -321,7 +321,7 @@ namespace :api do
 end
 ```
 
-Now add the controller
+Now add the controller:
 
 ```ruby
 # rails/app/controllers/api/speakers_controller.rb
@@ -336,7 +336,7 @@ class Api::SpeakersController < ApplicationController
 end
 ```
 
-Finally we need to generate a serializer `rails g serializer speaker`
+Finally we need to generate a serializer `rails g serializer speaker`.
 
 Add `name` to the list of attributes to serialize
 

--- a/source/posts/2014-05-09-building-an-ember-app-with-rails-part-3.md
+++ b/source/posts/2014-05-09-building-an-ember-app-with-rails-part-3.md
@@ -92,7 +92,7 @@ test('Should allow navigating back to root from another page', function() {
 ```
 
 ```js
-// ember/templates/application.hbs
+// ember/app/templates/application.hbs
 {{link-to 'Home' 'application'}}
 {{link-to 'About' 'about'}}
 ```
@@ -281,7 +281,7 @@ export default Ember.Route.extend({
 ```
 
 ```hbs
-// ember/templates/speakers/index.hbs
+// ember/app/templates/speakers/index.hbs
 {{#each}}
   {{link-to name 'speakers.show' this}}
 {{/each}}
@@ -290,7 +290,7 @@ export default Ember.Route.extend({
 The 2nd test should now be passing.
 
 ```hbs
-// ember/templates/speakers/show.hbs
+// ember/app/templates/speakers/show.hbs
 <h4>{{name}}</h4>
 ```
 

--- a/source/posts/2014-05-31-building-an-ember-app-with-rails-part-4.md
+++ b/source/posts/2014-05-31-building-an-ember-app-with-rails-part-4.md
@@ -224,7 +224,7 @@ end
 Finally we need to modify the serializers.
 
 ```ruby
-# rails/app/serializers/presentation.rb
+# rails/app/serializers/presentation_serializer.rb
 
 class PresentationSerializer < ActiveModel::Serializer
   attributes :id, :title
@@ -232,7 +232,7 @@ end
 ```
 
 ```ruby
-# rails/app/serializers/speaker.rb
+# rails/app/serializers/speaker_serializer.rb
 
 class SpeakerSerializer < ActiveModel::Serializer
   embed :ids, include: true


### PR DESCRIPTION
Major-ish fixes:
* Rails 4.2 only works with `active_model_serializers` version 0.8.3
* Use `--skip-git` flag when creating new ember app.
* Fix instructions for including `ember-cli-pretender`
* Import correct modules in tests

Plus some minor fixes, such as:
* Typos
* Use `git add -A` instead of `git add .`
* Etc.

Thanks for the tutorial!