### PR TITLE
Update 2015-02-06-embe-qunit-0-2.md

### DIFF
--- a/source/posts/2015-02-06-ember-qunit-0-2.md
+++ b/source/posts/2015-02-06-ember-qunit-0-2.md
@@ -134,12 +134,12 @@ import { test, moduleForComponent } from 'ember-qunit';
 
 moduleForComponent('awesome-sauce');
 
-test('implements awesomeness', function() {
+test('implements awesomeness', function(assert) {
   var component = this.subject();
 
   this.render();
 
-  equal(component.$().text(), 'WHOAA!! AWESOME!!!');
+  assert.equal(component.$().text(), 'WHOAA!! AWESOME!!!');
 });
 ```
 


### PR DESCRIPTION
The last example of components changing to use `this.render()` instead of `this.append()` shows using the global `equal`, which is mentioned as being deprecated in the first example of the blog post. Change the refactored use of `this.render()` to also show using the passed in `assert`.