### PR TITLE
Fix undefined variable problem

### DIFF
--- a/source/posts/2014-05-09-building-an-ember-app-with-rails-part-3.md
+++ b/source/posts/2014-05-09-building-an-ember-app-with-rails-part-3.md
@@ -209,7 +209,7 @@ test('Should list all speakers', function(assert) {
 
 test('Should be able to navigate to a speaker page', function(assert) {
   visit('/speakers').then(function() {
-    click('a:contains("Bugs Bunny")').then(function(assert) {
+    click('a:contains("Bugs Bunny")').then(function() {
       assert.equal(find('h4').text(), 'Bugs Bunny');
     });
   });


### PR DESCRIPTION
Test was failing for me until I removed that function argument.

Before:
```
Integration - Speakers Page: Should be able to navigate to a speaker (1, 0, 1)
TypeError: Cannot read property 'equal' of undefined@ 114 ms
Expected: 	
true
Result: 	
false
```

After:
```
Tests completed in 524 milliseconds.
15 assertions of 15 passed, 0 failed.
```