### PR TITLE
RSS feed: Use last git commit date instead of file system modified time

### DIFF
--- a/source/atom.xml.builder
+++ b/source/atom.xml.builder
@@ -9,12 +9,18 @@ xml.feed 'xmlns' => 'http://www.w3.org/2005/Atom' do
   xml.author { xml.name 'DockYard' }
 
   blog.articles.select { |art| art.data.published }.each do |article|
+    if `git log #{article.source_file}`.empty? # If it's a new post
+      last_updated = article.date.to_time
+    else
+      last_updated = Time.parse(`git log -1 --format=%cd #{article.source_file}`)
+    end
+
     xml.entry do
       xml.title article.title
       xml.link 'rel' => 'alternate', 'href' => URI.join(site_url, article.url)
       xml.id URI.join(site_url, article.url)
       xml.published article.date.to_time.iso8601
-      xml.updated File.mtime(article.source_file).iso8601
+      xml.updated last_updated.iso8601
       xml.author { xml.name article.author }
       xml.summary article.summary
       xml.content article.body, 'type' => 'html'


### PR DESCRIPTION
If you look at the current Atom feed: http://reefpoints.dockyard.com/atom.xml (Firefox parses it for you, Chrome doesn't) you'll see all the dates are "April 22, 2015 at 08:47". 

I imagine that's the time of last deploy (or time of cloning for whoever cloned it).

Instead, this patch uses the last git commit time. If it's a new post (i.e. not in git), it'll use the publish date from the file name instead.

Note: the current time has a timezone error. In EDT (UTC -400), a post with the date 04-24-2015 will say it's original post date is 04-23-2015 at 8PM. Not sure if you want to change that to midnight on 04-24-2015 (or maybe noon even?)
