### PR TITLE
Add ember start version to Brian's posts

### DIFF
--- a/source/posts/2013-01-09-building-an-ember-app-with-rails-api-part-2.md
+++ b/source/posts/2013-01-09-building-an-ember-app-with-rails-api-part-2.md
@@ -9,6 +9,7 @@ legacy_category: ember
 social: true
 summary: "Building the Ember app"
 published: true
+ember_start_version: '0.9.8'
 tags: javascript, ruby on rails
 ---
 

--- a/source/posts/2013-02-21-ember-easy-form.md
+++ b/source/posts/2013-02-21-ember-easy-form.md
@@ -9,6 +9,7 @@ legacy_category: ember
 social: true
 summary: "A SimpleForm-like FormBuilder for Ember"
 published: true
+ember_start_version: '1.0'
 tags: javascript, ember libraries
 ---
 

--- a/source/posts/2013-03-27-body-class-tags-in-ember.md
+++ b/source/posts/2013-03-27-body-class-tags-in-ember.md
@@ -9,6 +9,7 @@ legacy_category: ember
 social: true
 summary: "For design!"
 published: true
+ember_start_version: '0.9.8'
 tags: javascript, design
 ---
 

--- a/source/posts/2013-12-19-ember-enum-property-cycler.md
+++ b/source/posts/2013-12-19-ember-enum-property-cycler.md
@@ -9,6 +9,7 @@ social: true
 summary: 'A quick demo of cycling between a set of values'
 published: true
 tags: ember
+ember_start_version: '1.0'
 ---
 
 This is a quick one. I needed to cycle between the values in a set.

--- a/source/posts/2014-03-03-a-simple-ember-data-route.md
+++ b/source/posts/2014-03-03-a-simple-ember-data-route.md
@@ -8,6 +8,7 @@ github: bcardarella
 social: true
 summary: "A basic pattern for routes with Ember Data content"
 published: true
+ember_start_version: '1.4'
 tags: ember
 ---
 

--- a/source/posts/2014-04-28-dont-override-init.md
+++ b/source/posts/2014-04-28-dont-override-init.md
@@ -9,6 +9,7 @@ social: true
 summary: Use events instead
 published: true
 tags: ember, best practices
+ember_start_version: '1.5'
 ---
 
 Too frequently I see the following problem. Someone creates a new

--- a/source/posts/2014-05-05-preserve-scroll-position-in-ember-apps.md
+++ b/source/posts/2014-05-05-preserve-scroll-position-in-ember-apps.md
@@ -9,6 +9,7 @@ social: true
 summary: A simple mixin for your views
 published: true
 tags: ember
+ember_start_version: '1.5'
 ---
 
 If you have a long list of items on a page and a user follows a link

--- a/source/posts/2014-05-07-building-an-ember-app-with-rails-part-1.md
+++ b/source/posts/2014-05-07-building-an-ember-app-with-rails-part-1.md
@@ -9,6 +9,7 @@ social: true
 summary: ember-cli & Rails
 published: true
 tags: ember, ruby, ruby on rails
+ember_start_version: '1.5'
 ---
 *This is a four-part series:
 [Part 1](http://reefpoints.dockyard.com/2014/05/07/building-an-ember-app-with-rails-part-1.html),

--- a/source/posts/2014-05-08-building-an-ember-app-with-rails-part-2.md
+++ b/source/posts/2014-05-08-building-an-ember-app-with-rails-part-2.md
@@ -9,6 +9,7 @@ social: true
 summary: Writing our first ember test
 published: true
 tags: ember, ruby, ruby on rails
+ember_start_version: '1.5'
 ---
 
 *This is a four-part series:

--- a/source/posts/2014-05-09-building-an-ember-app-with-rails-part-3.md
+++ b/source/posts/2014-05-09-building-an-ember-app-with-rails-part-3.md
@@ -8,6 +8,7 @@ twitter: bcardarella
 social: true
 published: true
 tags: ember, ruby, ruby on rails
+ember_start_version: '1.5'
 ---
 
 *This is a four-part series:

--- a/source/posts/2014-05-31-building-an-ember-app-with-rails-part-4.md
+++ b/source/posts/2014-05-31-building-an-ember-app-with-rails-part-4.md
@@ -8,6 +8,7 @@ twitter: bcardarella
 social: true
 published: true
 tags: ember, ruby, ruby on rails
+ember_start_version: '1.5'
 ---
 
 *This is a four-part series:

--- a/source/posts/2014-11-28-ember-wish-list.md
+++ b/source/posts/2014-11-28-ember-wish-list.md
@@ -7,6 +7,7 @@ twitter: 'bcardarella'
 social: true
 published: true
 tags: ember, opinion
+ember_start_version: '1.8'
 ---
 
 It's getting close to Christmas and I've got a few things on my list for

--- a/source/posts/2015-03-22-tips-for-writing-ember-addons.md
+++ b/source/posts/2015-03-22-tips-for-writing-ember-addons.md
@@ -7,6 +7,7 @@ twitter: 'bcardarella'
 social: true
 published: true
 tags: ember, javascript
+ember_start_version: '1.10'
 ---
 
 After having published many Ember addons I have started to develop my

--- a/source/posts/2015-08-08-polymorphic-urls-in-ember.md
+++ b/source/posts/2015-08-08-polymorphic-urls-in-ember.md
@@ -7,6 +7,7 @@ twitter: bcardarella
 github: bcardarella
 published: true
 tags: ember, javascript
+ember_start_version: '1.13'
 ---
 
 Ember makes it easy to consume polymorphic records, assuming you have


### PR DESCRIPTION
I added ember_start_version based on publish date. I pulled this timeline from https://github.com/emberjs/ember.js/releases. I stuck to ones about ember content, and skipped ones doing things like introducing addons, etc.
Please do two things, then either push fixes to the branch or just give a 'looks good'. 
1. Check if the start versions make sense. I went through 45 posts, so I probably did something silly somewhere.
2. Evaluate if the content is still relevant/accurate for modern ember development. If so, just leave as is. If nt, try to find where the feature was deprecated, or where a better alternative was introduced, and add `ember_end_version` to the front matter of the post.