### PR TITLE
Add ember_start_version to Alex Navasardyan's posts

### DIFF
--- a/source/posts/2013-09-04-computed_properties_in_ember_js.md
+++ b/source/posts/2013-09-04-computed_properties_in_ember_js.md
@@ -10,6 +10,7 @@ social: true
 published: true
 comments: true
 summary: 'Computed Properties magic explained'
+ember_start_version: '1.0'
 ---
 
 Note: Short version of this post is a part of [Ember.Js

--- a/source/posts/2014-04-17-ember-object-self-troll.md
+++ b/source/posts/2014-04-17-ember-object-self-troll.md
@@ -9,6 +9,7 @@ social: true
 published: true
 comments: true
 summary: 'Ember.Object.create explained'
+ember_start_version: '1.5'
 ---
 
 Let's say we have a `Month` object. A `Month` has `weeks`.


### PR DESCRIPTION
I added ember_start_version based on publish date. I pulled this timeline from https://github.com/emberjs/ember.js/releases. I stuck to ones about ember content, and skipped ones doing things like introducing addons, etc.
Please do two things, then either push fixes to the branch or just give a 'looks good'. 
1. Check if the start versions make sense. I went through 45 posts, so I probably did something silly somewhere.
2. Evaluate if the content is still relevant/accurate for modern ember development. If so, just leave as is. If nt, try to find where the feature was deprecated, or where a better alternative was introduced, and add `ember_end_version` to the front matter of the post.