### PR TITLE
Add ember_start_version to Lin's post

### DIFF
--- a/source/posts/2014-06-27-ember-macros-for-DRY-and-testable-code.md
+++ b/source/posts/2014-06-27-ember-macros-for-DRY-and-testable-code.md
@@ -9,6 +9,7 @@ social: true
 comments: true
 published: true
 tags: ember, testing, best practices
+ember_start_version: '1.5'
 ---
 
 ### Intro


### PR DESCRIPTION
I added ember_start_version based on publish date. I pulled this timeline from https://github.com/emberjs/ember.js/releases. I stuck to ones about ember content, and skipped ones doing things like introducing addons, etc.
Please do two things, then either push fixes to the branch or just give a 'looks good'. 
1. Check if the start versions make sense. I went through 45 posts, so I probably did something silly somewhere.
2. Evaluate if the content is still relevant/accurate for modern ember development. If so, just leave as is. If nt, try to find where the feature was deprecated, or where a better alternative was introduced, and add `ember_end_version` to the front matter of the post.