### PR TITLE
Add ember_start_version to Lauren's posts

### DIFF
--- a/source/posts/2015-04-20-ember-in-viewport.md
+++ b/source/posts/2015-04-20-ember-in-viewport.md
@@ -8,6 +8,7 @@ tags: ember, addon, javascript
 social: true
 comments: true
 published: true
+ember_start_version: '1.11'
 summary: "I wrote a post last year about how I made an Ember Mixin that would let Ember Components or Views know if their DOM element had entered or left the viewport. This time, I want to talk about how I improved the original Mixin to use the requestAnimationFrame API for improved performance at close to 60FPS."
 ---
 

--- a/source/posts/2015-06-02-ember-crumbly.md
+++ b/source/posts/2015-06-02-ember-crumbly.md
@@ -9,6 +9,7 @@ social: true
 comments: true
 published: true
 summary: "ember-crubmly is a simple Component that is placed once in your application, and then generates a dynamic breadcrumb by looking up the current route hierarchy. The addon has a simple declarative API, which makes integration with your app super easy."
+ember_start_version: '1.12'
 ---
 
 Breadcrumb navigation isn't a new concept, in fact, it's usefulness has been endlessly debated about by UX designers all over. Today, I won't get into the nitty gritty on whether or not your app should include one, but I'd like to share an addon I built for a project I'm working on that required it.


### PR DESCRIPTION
I added ember_start_version based on publish date. I pulled this timeline from https://github.com/emberjs/ember.js/releases. I stuck to ones about ember content, and skipped ones doing things like introducing addons, etc.
Please do two things, then either push fixes to the branch or just give a 'looks good'. 
1. Check if the start versions make sense. I went through 45 posts, so I probably did something silly somewhere.
2. Evaluate if the content is still relevant/accurate for modern ember development. If so, just leave as is. If nt, try to find where the feature was deprecated, or where a better alternative was introduced, and add `ember_end_version` to the front matter of the post.