### PR TITLE
Add ember_start_version to Estelle's post

### DIFF
--- a/source/posts/2015-09-18-ember-best-practices-avoid-leaking-state-into-factories.md
+++ b/source/posts/2015-09-18-ember-best-practices-avoid-leaking-state-into-factories.md
@@ -8,6 +8,7 @@ tags: ember, javascript
 social: true
 comments: true
 published: true
+ember_start_version: '1.13'
 ---
 
 At DockYard, we spend a lot of time with Ember, from building web apps, creating and maintaining addons, to contributing back to the Ember ecosystem. We hope to share some of the experience we've gathered along the way through a series of blog posts that will focus on idiomatic Ember practices, patterns, anti-patterns, and common pitfalls. This is the first in that series, so let's start by going back to the basics with `Ember.Object`.


### PR DESCRIPTION
I added ember_start_version based on publish date. I pulled this timeline from https://github.com/emberjs/ember.js/releases. I stuck to ones about ember content, and skipped ones doing things like introducing addons, etc.
Please do two things, then either push fixes to the branch or just give a 'looks good'. 
1. Check if the start versions make sense. I went through 45 posts, so I probably did something silly somewhere.
2. Evaluate if the content is still relevant/accurate for modern ember development. If so, just leave as is. If nt, try to find where the feature was deprecated, or where a better alternative was introduced, and add `ember_end_version` to the front matter of the post.