### PR TITLE
Add ember_start_version to rob's post

### DIFF
--- a/source/posts/2015-02-06-ember-qunit-0-2.md
+++ b/source/posts/2015-02-06-ember-qunit-0-2.md
@@ -8,6 +8,7 @@ tags: ember-cli, testing, ember.js
 social: true
 comments: true
 published: true
+ember_start_version: '1.10'
 ---
 
 [Ember QUnit](https://github.com/rwjblue/ember-qunit) 0.2.x has been released. It brings a whole bunch of bug fixes and some much needed cleanup, but there are a couple breaking changes also.


### PR DESCRIPTION
I added ember_start_version based on publish date. I pulled this timeline from https://github.com/emberjs/ember.js/releases. I stuck to ones about ember content, and skipped ones doing things like introducing addons, etc.
Please do two things, then either push fixes to the branch or just give a 'looks good'. 
1. Check if the start versions make sense. I went through 45 posts, so I probably did something silly somewhere.
2. Evaluate if the content is still relevant/accurate for modern ember development. If so, just leave as is. If nt, try to find where the feature was deprecated, or where a better alternative was introduced, and add `ember_end_version` to the front matter of the post.