### PR TITLE
Add ember_start_version to Dan's posts

### DIFF
--- a/source/posts/2015-01-28-bubbling-actions-through-components.md
+++ b/source/posts/2015-01-28-bubbling-actions-through-components.md
@@ -10,6 +10,8 @@ social: true
 summary: "Let your actions be handled in your controllers and routes"
 published: true
 tags: emberjs
+ember_start_version: '1.9'
+ember_start_version: '1.13'
 ---
 
 If you're building components for re-use, you're likely to run into the

--- a/source/posts/2015-06-08-a-clean-pattern-for-modal-dialogs.md
+++ b/source/posts/2015-06-08-a-clean-pattern-for-modal-dialogs.md
@@ -10,6 +10,7 @@ social: true
 summary: "The project you are working on has a number of modal dialogs, and the component helper can help"
 published: true
 tags: ember, components
+ember_start_version: '1.12'
 ---
 
 Recently, I was working on a project which had a number of different modals. I

--- a/source/posts/2015-07-24-using-bare-arguments-with-ember-components.md
+++ b/source/posts/2015-07-24-using-bare-arguments-with-ember-components.md
@@ -10,6 +10,7 @@ social: true
 summary: "Positional parameters help you create cleaner APIs for your components"
 published: true
 tags: ember
+ember_start_version: '1.13'
 ---
 
 [`ember-cli-async-button`](https://github.com/dockyard/ember-cli-async-button)


### PR DESCRIPTION
I added ember_start_version based on publish date. I pulled this timeline from https://github.com/emberjs/ember.js/releases. I stuck to ones about ember content, and skipped ones doing things like introducing addons, etc.
Please do two things, then either push fixes to the branch or just give a 'looks good'. 
1. Check if the start versions make sense. I went through 45 posts, so I probably did something silly somewhere.
2. Evaluate if the content is still relevant/accurate for modern ember development. If so, just leave as is. If nt, try to find where the feature was deprecated, or where a better alternative was introduced, and add `ember_end_version` to the front matter of the post.