### PR TITLE
Use https to fix mixed content warning

### DIFF
--- a/source/posts/2016-08-12-pieces-of-ember-part1.md
+++ b/source/posts/2016-08-12-pieces-of-ember-part1.md
@@ -17,7 +17,7 @@ What these developers probably don't know is that many of the core pieces that m
 
 <br><br>
 <div style="text-align:center;">
-  <img src="http://i.imgur.com/PfqFoEW.png">
+  <img src="https://i.imgur.com/PfqFoEW.png">
 </div>
 <br><br>
 


### PR DESCRIPTION
Updates an image src to use https rather than http to avoid mixed content warnings.

![screen shot 2016-08-29 at 10 08 41 pm](https://cloud.githubusercontent.com/assets/602204/18076783/905f8798-6e35-11e6-9363-d8c88c4aa2b2.png)

More info about why at https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content